### PR TITLE
Fix deployment scripts and add unit tests

### DIFF
--- a/scripts/DeploymentController.ts
+++ b/scripts/DeploymentController.ts
@@ -3,11 +3,7 @@
 /**
  * @title DeploymentController
  * @notice TypeScript controller for QuikDB simplified contract deployment
- * @dev Manage    writeFileSync(addressesFile, JSON.stringify(simpleAddresses, null, 2));
-    console.log(`   ✅ addresses.json`);
-
-    console.log(`📁 All deployment files saved to deployments/ directory`);
-  }ent across different networks with simplified architecture
+ * @dev Manages running the forge script and saving resulting addresses
  */
 
 import { exec } from 'child_process';
@@ -150,10 +146,6 @@ class DeploymentController {
     console.log(`   ✅ addresses.json`);
 
     console.log(`📁 All deployment files saved to deployments/ directory`);
-    writeFileSync(addressesFile, JSON.stringify(simpleAddresses, null, 2));
-    console.log(`   ✅ addresses.json`);
-
-    console.log(`� All deployment files saved to deployments/ directory`);
   }
 }
 

--- a/scripts/QuikDBDeployment.sol
+++ b/scripts/QuikDBDeployment.sol
@@ -1,17 +1,5 @@
 // SPDX-License-Identifier: MIT
-prag        // Deploy QuiksToken implementation  
-        QuiksToken tokenImpl = new QuiksToken{salt: salt}();
-        
-        // Deploy proxy for QuiksToken
-        bytes memory tokenInitData = abi.encodeWithSelector(
-            QuiksToken.initialize.selector,
-            "QuikDB Token",
-            "QUIKS", 
-            1000000000 ether, // 1 billion tokens
-            msg.sender // deployer becomes owner
-        );
-        
-        ERC1967Proxy tokenProxy = new ERC1967Proxy{salt: salt}(0.8.20;
+pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";
 import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
@@ -24,47 +12,46 @@ import "../src/tokens/QuiksToken.sol";
  * @dev Uses CREATE2 for predictable addresses across networks
  */
 contract QuikDBDeployment is Script {
-    
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         vm.startBroadcast(deployerPrivateKey);
-        
+
         // Generate unique salt based on timestamp to avoid collisions
         bytes32 salt = keccak256(abi.encodePacked("QuikDB_v1.1", block.timestamp));
-        
+
         // Deploy UserNodeRegistry implementation
         UserNodeRegistry registryImpl = new UserNodeRegistry{salt: salt}();
-        
+
         // Deploy proxy for UserNodeRegistry
         bytes memory registryInitData = abi.encodeWithSelector(
             UserNodeRegistry.initialize.selector,
-            msg.sender // deployer becomes owner
+            msg.sender
         );
-        
+
         ERC1967Proxy registryProxy = new ERC1967Proxy{salt: salt}(
             address(registryImpl),
             registryInitData
         );
-        
+
         // Deploy QuiksToken implementation
-        QuiksToken tokenImpl = new QuiksToken{salt: SALT}();
-        
+        QuiksToken tokenImpl = new QuiksToken{salt: salt}();
+
         // Deploy proxy for QuiksToken
         bytes memory tokenInitData = abi.encodeWithSelector(
             QuiksToken.initialize.selector,
             "QuikDB Token",
             "QUIKS",
-            1000000000 * 10**18, // 1 billion tokens
-            msg.sender // deployer becomes owner
+            1000000000 * 10**18,
+            msg.sender
         );
-        
-        ERC1967Proxy tokenProxy = new ERC1967Proxy{salt: SALT}(
+
+        ERC1967Proxy tokenProxy = new ERC1967Proxy{salt: salt}(
             address(tokenImpl),
             tokenInitData
         );
-        
+
         vm.stopBroadcast();
-        
+
         // Output addresses for CLI consumption
         console.log("UserNodeRegistry:", address(registryProxy));
         console.log("UserNodeRegistryImpl:", address(registryImpl));
@@ -72,3 +59,4 @@ contract QuikDBDeployment is Script {
         console.log("QuiksTokenImpl:", address(tokenImpl));
     }
 }
+

--- a/test/QuikDB.t.sol
+++ b/test/QuikDB.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/tokens/QuiksToken.sol";
+import "../src/UserNodeRegistry.sol";
+
+contract QuikDBTest is Test {
+    QuiksToken token;
+    UserNodeRegistry registry;
+
+    address owner = address(0xABCD);
+    address user = address(0x1000);
+    address operator = address(0x2000);
+
+    function setUp() public {
+        token = new QuiksToken();
+        token.initialize("QuikDB Token", "QUIKS", 0, owner);
+
+        registry = new UserNodeRegistry();
+        registry.initialize(owner);
+    }
+
+    function testOwnerSet() public {
+        assertEq(token.owner(), owner);
+        assertEq(registry.owner(), owner);
+    }
+
+    function testMintByOwner() public {
+        vm.prank(owner);
+        token.mint(user, 123);
+        assertEq(token.balanceOf(user), 123);
+    }
+
+    function testRegisterUser() public {
+        vm.prank(user);
+        registry.registerUser(user, bytes32("profile"), UserNodeRegistry.UserType.CONSUMER);
+        (address addr,, UserNodeRegistry.UserType utype,, , , ,) = registry.users(user);
+        assertEq(addr, user);
+        assertEq(uint256(utype), uint256(UserNodeRegistry.UserType.CONSUMER));
+    }
+
+    function testRegisterNode() public {
+        vm.prank(owner);
+        registry.registerNode(operator, bytes32("meta"), UserNodeRegistry.NodeTier.BASIC, UserNodeRegistry.ProviderType.STORAGE);
+        (address op,, UserNodeRegistry.NodeTier tier, UserNodeRegistry.ProviderType ptype,, , , , , , , ,) = registry.nodes(operator);
+        assertEq(op, operator);
+        assertEq(uint256(tier), uint256(UserNodeRegistry.NodeTier.BASIC));
+        assertEq(uint256(ptype), uint256(UserNodeRegistry.ProviderType.STORAGE));
+    }
+
+    function testPauseUnpause() public {
+        vm.prank(owner);
+        registry.pause();
+        assertTrue(registry.paused());
+        vm.prank(owner);
+        registry.unpause();
+        assertFalse(registry.paused());
+    }
+}


### PR DESCRIPTION
## Summary
- repair the `QuikDBDeployment` forge script
- clean up and simplify the TypeScript deployment controller
- add basic Foundry tests for the token and registry

## Testing
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884fe5e8978832aab14657e70aa8847